### PR TITLE
Device Type Ban Update #2

### DIFF
--- a/Safeguard anti-cheat B/scripts/command/importer.js
+++ b/Safeguard anti-cheat B/scripts/command/importer.js
@@ -15,5 +15,6 @@ import "../command/src/notify";
 import "../command/src/worldborder";
 import "../command/src/help";
 import "../command/src/admin-kit"
-
+import "../command/src/dtban"
+import "../command/src/devinfo"
 import "../command/src/report";

--- a/Safeguard anti-cheat B/scripts/command/src/devinfo.js
+++ b/Safeguard anti-cheat B/scripts/command/src/devinfo.js
@@ -1,0 +1,24 @@
+import { canFindPlayer, getPlayerByName } from '../../assets/util';
+import { newCommand } from '../handle';
+
+newCommand({
+    name: "devinfo",
+    description: "<player name> Displays device information of a player",
+    run: (data) => {
+        const { player } = data;
+        const playerName = data.args.slice(1).join(" ");
+
+        if (!player.hasTag("admin")) return;
+
+        const targetPlayer = canFindPlayer(playerName) ? getPlayerByName(playerName) : null;
+        if (!targetPlayer) {
+            player.sendMessage(`§6[§eSafeGuard§6]§f Player §e${playerName}§f was not found`);
+            return;
+        }
+
+        player.sendMessage(`Player Name: ${targetPlayer.name}`);
+        player.sendMessage(`Platform Type: ${targetPlayer.clientSystemInfo.platformType}`);
+        player.sendMessage(`System Memory: ${targetPlayer.clientSystemInfo.memoryTier}`);
+        player.sendMessage(`Max Render Distance: ${targetPlayer.clientSystemInfo.maxRenderDistance}`)
+    }
+});

--- a/Safeguard anti-cheat B/scripts/command/src/dtban.js
+++ b/Safeguard anti-cheat B/scripts/command/src/dtban.js
@@ -1,0 +1,34 @@
+import { world } from "@minecraft/server";
+import { newCommand } from '../handle';
+
+let devicebanlist = [];
+newCommand({
+    name: "dtban",
+    description: "<ban/unban/list> <device type> Manages device bans",
+    run: (data) => {
+        const { player } = data;
+        const args = data.args.slice(1);
+
+        if (!player.hasTag("admin")) return;
+
+        if (args[0] === "ban") {
+            const deviceType = args[1];
+            devicebanlist.push(deviceType);
+            world.setDynamicProperty("dbl", `[${devicebanlist.join(", ")}]`)
+            player.sendMessage(`Platform "${deviceType}" Banned`);
+        } else if (args[0] === "unban") {
+            const deviceType = args[1];
+            if (!devicebanlist.includes(deviceType)) {
+                player.sendMessage(`Device Type "${deviceType}" not found in banned list`);
+            } else {
+                devicebanlist = devicebanlist.filter(x => x !== deviceType);
+                world.setDynamicProperty("dbl", `[${devicebanlist.join(", ")}]`)
+                player.sendMessage(`Platform "${deviceType}" Unbanned`);
+            }
+        } else if (args[0] === "list") {
+            player.sendMessage(`List of banned devices: [${devicebanlist.join(", ")}]`);
+        } else {
+            player.sendMessage(`§6[§eSafeGuard§6]§f Invalid command. Use ban, unban, or list.`);
+        }
+    }
+});

--- a/Safeguard anti-cheat B/scripts/command/src/dtban.js
+++ b/Safeguard anti-cheat B/scripts/command/src/dtban.js
@@ -1,7 +1,9 @@
 import { world } from "@minecraft/server";
 import { newCommand } from '../handle';
-
-let devicebanlist = [];
+let dbl = world.getDynamicProperty("dbl").toString()
+let b1 = (dbl.lastIndexOf("[") + 1);
+let b2 = (dbl.indexOf("]"));
+let devicebanlist = dbl.slice(b1, b2).split(", ");
 newCommand({
     name: "dtban",
     description: "<ban/unban/list> <device type> Manages device bans",

--- a/Safeguard anti-cheat B/scripts/index.js
+++ b/Safeguard anti-cheat B/scripts/index.js
@@ -107,7 +107,19 @@ world.beforeEvents.chatSend.subscribe((data) => {
   
 	commandHandler(data);
 })
-  
+
+let dbl = world.getDynamicProperty("dbl").toString()
+let b1 = (dbl.indexOf("[") + 1);
+let b2 = (dbl.indexOf("]"));
+let devicebanlist = dbl.slice(b1, b2).split(", ");
+Minecraft.system.runInterval(() => {
+	for (const player of world.getPlayers()) {
+		if (devicebanlist.includes(player.clientSystemInfo.platformType) && !player.hasTag("admin") || !player.isOp() || !player.hasTag("dtbypass")) {
+			player.sendMessage("you are on a banned device")
+			player.dimension.runCommandAsync(`kick "${player.name}" §r§6[§eSafeGuard§6]§r §4You are banned from joining on this device type find another device type.\n§4Reason: §cPlaying on ${player.clientSystemInfo.platformType} \n§4Banned by: §cThe Device Ban Hammer`)
+		}
+	}
+})
 
 //anti nuker
 world.afterEvents.playerBreakBlock.subscribe((data) => {

--- a/Safeguard anti-cheat B/scripts/index.js
+++ b/Safeguard anti-cheat B/scripts/index.js
@@ -109,14 +109,17 @@ world.beforeEvents.chatSend.subscribe((data) => {
 })
 
 let dbl = world.getDynamicProperty("dbl").toString()
-let b1 = (dbl.indexOf("[") + 1);
+let b1 = (dbl.lastIndexOf("[") + 1);
 let b2 = (dbl.indexOf("]"));
 let devicebanlist = dbl.slice(b1, b2).split(", ");
+export let d = ["Placeholder"];
 Minecraft.system.runInterval(() => {
 	for (const player of world.getPlayers()) {
-		if (devicebanlist.includes(player.clientSystemInfo.platformType) && !player.hasTag("admin") || !player.isOp() || !player.hasTag("dtbypass")) {
+		if (!player.hasTag("admin") || !player.isOp() || !player.hasTag("dtbypass") {
+		if (devicebanlist.includes(player.clientSystemInfo.platformType) && (!player.hasTag("admin") || !player.isOp() || !player.hasTag("dtbypass"))) {
 			player.sendMessage("you are on a banned device")
 			player.dimension.runCommandAsync(`kick "${player.name}" §r§6[§eSafeGuard§6]§r §4You are banned from joining on this device type find another device type.\n§4Reason: §cPlaying on ${player.clientSystemInfo.platformType} \n§4Banned by: §cThe Device Ban Hammer`)
+		}
 		}
 	}
 })

--- a/Safeguard anti-cheat B/scripts/index.js
+++ b/Safeguard anti-cheat B/scripts/index.js
@@ -116,7 +116,7 @@ export let d = ["Placeholder"];
 Minecraft.system.runInterval(() => {
 	for (const player of world.getPlayers()) {
 		if (!player.hasTag("admin") || !player.isOp() || !player.hasTag("dtbypass") {
-		if (devicebanlist.includes(player.clientSystemInfo.platformType) && (!player.hasTag("admin") || !player.isOp() || !player.hasTag("dtbypass"))) {
+		if (devicebanlist.includes(player.clientSystemInfo.platformType)) {
 			player.sendMessage("you are on a banned device")
 			player.dimension.runCommandAsync(`kick "${player.name}" §r§6[§eSafeGuard§6]§r §4You are banned from joining on this device type find another device type.\n§4Reason: §cPlaying on ${player.clientSystemInfo.platformType} \n§4Banned by: §cThe Device Ban Hammer`)
 		}


### PR DESCRIPTION
2 new commands:
Command 1:
dtban <ban/unban/list> Manages device bans
ban: bans a device type
unban: unbans a device type
list: lists the current banned device types
device types: [Desktop, Console, Mobile]
Command 2:
devinfo Displays device information of a player
Displays the device type, memory tier, and max render distance