### PR TITLE
Update fake_leave_server.mcfunction

### DIFF
--- a/Safeguard anti-cheat B/functions/admin_cmds/fake_leave_server.mcfunction
+++ b/Safeguard anti-cheat B/functions/admin_cmds/fake_leave_server.mcfunction
@@ -1,4 +1,4 @@
-execute as @s[tag=admin] run tellraw @a {"rawtext":[{"text":"§e"},{"selector":"@s"},{"text":" left the server"}]}
+execute as @s[tag=admin] run tellraw @a {"rawtext":[{"text":"§e"},{"selector":"@s"},{"text":" left the game"}]}
 tellraw @s {"rawtext":[{"text":"§6[§eSafeGuard§6]§a Fake left success!"}]}
 playsound random.levelup @s[tag=admin]
 tellraw @s[tag=!admin] {"rawtext":[{"text":"§6[§eSafeGuard§6]§r §4You need admin tag to run this!"}]}


### PR DESCRIPTION
Bedrock Dedicated Server uses "{player} left the game" not "{player} left the server"